### PR TITLE
fix: adjust radius for delay button to match small radius

### DIFF
--- a/src/Controls/LingmoDelayButton.qml
+++ b/src/Controls/LingmoDelayButton.qml
@@ -139,7 +139,7 @@ T.DelayButton {
     background: LingmoControlBackground {
         implicitWidth: 30
         implicitHeight: 30
-        radius: LingmoUnits.windowRadius
+        radius: LingmoUnits.smallRadius
         border.color: LingmoTheme.dark ? Qt.rgba(
                                           48 / 255, 48 / 255, 48 / 255,
                                           1) : Qt.rgba(188 / 255, 188 / 255, 188 / 255, 1)
@@ -157,7 +157,7 @@ T.DelayButton {
         }
         LingmoClip {
             anchors.fill: parent
-            radius: {return new Array(4).fill(LingmoUnits.windowRadius);}
+            radius: {return new Array(4).fill(LingmoUnits.smallRadius);}
             Rectangle {
                 id: rect_back
                 width: parent.width * control.progress


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  fix

* **What is the current behavior?** (You can also link to an open issue here)

  Delay button has wrong radius settings.

* **What is the new behavior (if this is a feature change)?**

  Correct them to LingmoUnits.smallRadius

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  No

* **Other information**:
