### PR TITLE
fix(ImageButton): fix the error of non-customable content

### DIFF
--- a/src/Controls/LingmoImageButton.qml
+++ b/src/Controls/LingmoImageButton.qml
@@ -1,8 +1,9 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Templates as T
 import LingmoUI
 
-Button {
+T.Button {
     id: control
     property string normalImage: ""
     property string hoveredImage: ""


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

```
QML QQuickItem: The current style does not support customization of this control (property: "background" item: QQuickItem(0x600001b165a0, parent=0x0, geometry=0,0 12x12)). Please customize a non-native style (such as Basic, Fusion, Material, etc). For more information, see: https://doc.qt.io/qt-6/qtquickcontrols2-customize.html#customization-reference
```

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
